### PR TITLE
Improves the detection of the user consent page

### DIFF
--- a/packages/chrome/entrypoints/allow_access_confirm.content.ts
+++ b/packages/chrome/entrypoints/allow_access_confirm.content.ts
@@ -5,60 +5,65 @@ export default defineContentScript({
   async main() {
     console.log("Granted: running allow_access_confirm...");
 
-    const hashParams = new URLSearchParams(window.location.hash.slice(2));
-    const clientId = hashParams.get("clientId");
-
-    if (!clientId) {
-      console.log("Granted: clientID parameter is missing in the URL hash.");
-      return;
-    }
-
-    // Create and insert the banner
-    const banner = document.createElement("div");
-    banner.textContent = "Granted is confirming your access automatically...";
-    banner.style.position = "fixed";
-    banner.style.top = "0";
-    banner.style.width = "100%";
-    banner.style.backgroundColor = "#25a749";
-    banner.style.color = "white";
-    banner.style.textAlign = "center";
-    banner.style.padding = "10px";
-    banner.style.zIndex = "1000";
-    banner.style.fontFamily =
-      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
-    document.body.prepend(banner);
-
-    const userCodeIsSet = await sendMessage("userCodeIsSet", undefined);
-    console.log({ userCodeIsSet });
-    if (userCodeIsSet) {
-      let attempts = 0;
-      const intervalId = setInterval(() => {
-        const allowAccessButton = document.querySelector(
-          '[data-testid="allow-access-button"]',
-        ) as HTMLElement;
-        if (allowAccessButton) {
-          console.log("Granted: found allow access button", allowAccessButton);
-          allowAccessButton.click();
-
-          let closeAttempts = 0;
-          const maxCloseAttempts = 10;
-          const closeMessageCheckInterval = setInterval(() => {
-            if (
-              document.body.textContent?.includes("You can close this window.")
-            ) {
-              clearInterval(closeMessageCheckInterval);
-              sendMessage("closeTab", undefined);
-            } else if (closeAttempts >= maxCloseAttempts) {
-              clearInterval(closeMessageCheckInterval);
-            }
-            closeAttempts++;
-          }, 200);
-          clearInterval(intervalId);
-        } else if (attempts >= 30) {
-          clearInterval(intervalId);
-        }
-        attempts++;
-      }, 200);
-    }
+    const start = Date.now();
+    const checkInterval = setInterval(() => {
+      if (document.body.textContent?.includes("Allow access to your data?")) {
+        clearInterval(checkInterval);
+        void automateConfirmAccess();
+      } else if (Date.now() - start > 20000) {
+        // 20 seconds
+        clearInterval(checkInterval);
+      }
+    }, 200);
   },
 });
+
+async function automateConfirmAccess() {
+  // Create and insert the banner
+  const banner = document.createElement("div");
+  banner.textContent = "Granted is confirming your access automatically...";
+  banner.style.position = "fixed";
+  banner.style.top = "0";
+  banner.style.width = "100%";
+  banner.style.backgroundColor = "#25a749";
+  banner.style.color = "white";
+  banner.style.textAlign = "center";
+  banner.style.padding = "10px";
+  banner.style.zIndex = "1000";
+  banner.style.fontFamily =
+    "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+  document.body.prepend(banner);
+
+  const userCodeIsSet = await sendMessage("userCodeIsSet", undefined);
+  console.log({ userCodeIsSet });
+  if (userCodeIsSet) {
+    let attempts = 0;
+    const intervalId = setInterval(() => {
+      const allowAccessButton = document.querySelector(
+        '[data-testid="allow-access-button"]',
+      ) as HTMLElement;
+      if (allowAccessButton) {
+        console.log("Granted: found allow access button", allowAccessButton);
+        allowAccessButton.click();
+
+        let closeAttempts = 0;
+        const maxCloseAttempts = 10;
+        const closeMessageCheckInterval = setInterval(() => {
+          if (
+            document.body.textContent?.includes("You can close this window.")
+          ) {
+            clearInterval(closeMessageCheckInterval);
+            sendMessage("closeTab", undefined);
+          } else if (closeAttempts >= maxCloseAttempts) {
+            clearInterval(closeMessageCheckInterval);
+          }
+          closeAttempts++;
+        }, 200);
+        clearInterval(intervalId);
+      } else if (attempts >= 30) {
+        clearInterval(intervalId);
+      }
+      attempts++;
+    }, 200);
+  }
+}


### PR DESCRIPTION
The IAM Identity Center loads a lot of client-side JavaScript, so our previous detection was not robust enough.

Automates the confirmation of this step, assuming that the _same browser tab_ has had a confirmation of the user code via Granted.

![image](https://github.com/user-attachments/assets/089ecc47-7bed-4daa-8fb3-0435cb7bae7c)
