### PR TITLE
Add manifest.json description

### DIFF
--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "granted-chrome-browser-extension",
-  "description": "manifest.json description",
+  "description": "Automate the AWS IAM Identity Center sign-in process.",
   "private": true,
   "version": "0.2.3",
   "type": "module",


### PR DESCRIPTION
Current description looks a bit strange in `chrome://extensions/`
![image](https://github.com/user-attachments/assets/50ccba9d-3141-4e85-bd06-9c5996d3f469)

Feel free to edit this PR, just thought I'd get it started.

Looks like this might also end up on your store page?
https://chromewebstore.google.com/detail/granted/cjjieeldgoohbkifkogalkmfpddeafcm
![image](https://github.com/user-attachments/assets/459b1d84-502a-49bb-ad69-e6ded106bea7)

PS. The store page also has a minor grammatical error "This Chrome extension **is** automates"